### PR TITLE
Monitor icon visibility and always keep the icon hidden

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,13 +35,30 @@ const A11yStatusIconHelper = new Lang.Class({
 
         // The ClutterActor representing the icon in the panel.
         this._iconActor = a11yElement.actor;
+
+        // Id for the handler used to connect to GSetting's signals.
+        this._handlerId = 0;
+    },
+
+    _onIconVisibilityChanged: function(actor) {
+        if (actor.is_visible()) {
+            actor.hide();
+        }
     },
 
     hideA11yElement: function() {
+        // Monitor changes to the icon's visibilty, so that we
+        // ensure the icon always keeps hidden, no-matter-what.
+        this._handlerId = this._iconActor.connect('notify::visible',
+                                                  Lang.bind(this, this._onIconVisibilityChanged));
         this._iconActor.hide();
     },
 
     restoreA11yElement: function() {
+        if (this._handlerId) {
+            this._iconActor.disconnect(this._handlerId);
+            this._handlerId = 0;
+        }
         this._iconActor.show();
     }
 });

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 /**
  Copyright 2012 Sebastian Ventura
  Copyright 2012 Meng Zhuo
+ Copyright 2015 Mario Sanchez Prada
  This file is part of Remove Accessibility.
 
  Remove Accessibility is free software: you can redistribute it and/or modify
@@ -17,22 +18,44 @@
  along with Remove Accessibility.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
+const Lang = imports.lang;
 const Main = imports.ui.main;
 
-function init() {}
+const A11yStatusIconHelper = new Lang.Class({
+    Name: 'A11yStatusIconHelper',
+
+    _init: function() {
+        // Get a reference to the right accessibility icon.
+        let a11yElement = null;
+        if (typeof Main.panel._statusArea === 'undefined') {
+            a11yElement = Main.panel.statusArea.a11y;
+        } else {
+            a11yElement = Main.panel._statusArea.a11y;
+        }
+
+        // The ClutterActor representing the icon in the panel.
+        this._iconActor = a11yElement.actor;
+    },
+
+    hideA11yElement: function() {
+        this._iconActor.hide();
+    },
+
+    restoreA11yElement: function() {
+        this._iconActor.show();
+    }
+});
+
+let _a11yHelper = null;
+
+function init() {
+}
 
 function enable() {
-    if (typeof Main.panel._statusArea === 'undefined') {
-        Main.panel.statusArea.a11y.actor.hide();
-    } else {
-        Main.panel._statusArea.a11y.actor.hide();
-    }
+    _a11yHelper = new A11yStatusIconHelper();
+    _a11yHelper.hideA11yElement();
 }
 
 function disable() {
-    if (typeof Main.panel._statusArea === 'undefined') {
-        Main.panel.statusArea.a11y.actor.show();
-    } else {
-        Main.panel._statusArea.a11y.actor.show();
-    }
+    _a11yHelper.restoreA11yElement();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.2","3.3","3.4","3.6","3.8"], "uuid": "removeaccesibility@lomegor", "name": "Remove Accessibility", "description": "Remove the accessibility button from the top panel."}
+{"shell-version": ["3.2","3.3","3.4","3.6","3.8","3.16","3.18"], "uuid": "removeaccesibility@lomegor", "name": "Remove Accessibility", "description": "Remove the accessibility button from the top panel."}


### PR DESCRIPTION
These changes make the extension to keep the icon invisible even if some other component changes the value of one of the GSettings keys that it's monitoring, which can cause the icon to become visible again.

For instance, if you have the unpatched version of this extension enabled and then you change the value of text-scaling-factor via some other tool (dconf-editor, [text scaler extension](https://extensions.gnome.org/extension/1018/text-scaler), a11y panel in gnome-control-center...), then the icon will show up again since it monitors that key and change its own visibility when a relevant event happens.

Thus, simply monitoring the ClutterActor's visibility to force it to be hidden if anyone else tries to say otherwise will fix the problem, making this extension's behaviour more consistent.
