### PR TITLE
Remove deprecated .actor call from a11yElement

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ const A11yStatusIconHelper = new Lang.Class({
         }
 
         // The ClutterActor representing the icon in the panel.
-        this._iconActor = a11yElement.actor;
+        this._iconActor = a11yElement;
 
         // Id for the handler used to connect to GSetting's signals.
         this._handlerId = 0;


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/487

Fixes https://github.com/lomegor/Remove-Accessibility/issues/9